### PR TITLE
feat(controller): improve the IP assignation to Kubernetes nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # scaleway-external-ip (this is a POC, all hell can break loose, use at your own risk)
 
-This project aims to bring some sort of IP failover mechanism, over Scaleway's new routed IP system. 
+This project aims to bring some sort of IP failover mechanism, over Scaleway's new routed IP system.
 
 ## Description
 
 scaleway-external-ip brings a new CRD: `ScwExternalIP`. This resource, with the help of Scaleway Routed IPs, will allow you to have a failover IP that always is pointing to a healthy node of the cluster.
 
-In order to make it work, you'll need a `ClusterIP` service, with the `.spec.externalIPs` set to the Scaleway Routed IPs (v4&v6, see limitations) you want to use for this service, like this: 
+In order to make it work, you'll need a `ClusterIP` service, with the `.spec.externalIPs` set to the Scaleway Routed IPs (v4&v6, see limitations) you want to use for this service, like this:
 
 ```yaml
 apiVersion: v1
@@ -26,8 +26,8 @@ spec:
     - dead::beef::1
 ```
 
-In this case, the service `myapp` will be exposed on the public endpoints `1.2.3.4:8080` and `dead::beef::1:8080`. 
-However, the IPs needs to be attached to a node in the cluster, and the addresses added to the interface. 
+In this case, the service `myapp` will be exposed on the public endpoints `1.2.3.4:8080` and `dead::beef::1:8080`.
+However, the IPs needs to be attached to a node in the cluster, and the addresses added to the interface.
 
 No worries, you just need to create the following `ScwExternalIP`:
 
@@ -38,7 +38,7 @@ metadata:
   name: myapp
 spec:
   service: myapp # name of the targeted service, in the same namespace
-  # supports the nodeSelector, when choosing a node to attach. 
+  # supports the nodeSelector, when choosing a node to attach.
   # the controller is already adding a selector on the IP's zone
   #nodeSelector:
   # TODO: ideas to add reverse, whitelist (might be done with a Cilium network policy though), ...
@@ -48,23 +48,19 @@ Once it's created (and if the agents and controller are running of course!), it 
 The agent will add the IP address on the Instance's interface on all nodes matchings the constraints, for a quick failover.
 Once a node is not ready, the IP is detached, and re-attached to another node matching the constraints.
 
-TODO: add a healtcheck mechanism for faster failure discovery
-TODO: or add a new CRD to manage IP addresses on the nodes, and check every X for last heartbeat
+- TODO: add a healtcheck mechanism for faster failure discovery
+- TODO: or add a new CRD to manage IP addresses on the nodes, and check every X for last heartbeat
 
 ## Limitations
 
 - No real IPv6 support right now, as the Kapsule cluster can't be dual stack. The IP will be confiugred on the host, but Cilium will reject connections because it's not ipv6 enable.
 - "Slow" failover, as it waits for the node to be not ready
-- Needs [IP Mobility](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/) to be enable to work
 
 ## Getting Started
 
 ### Warning
 
-Currently, Kubernetes Kapsule does not support IP mobility. There is a [workaround to manually migrate your nodes](https://www.scaleway.com/en/docs/compute/instances/api-cli/using-routed-ips/) which can be used.
-However, all your nodes needs to be migrated (with a reboot), and every new node added automatically will need to be migrated too.
-
-As usual, please don't do this on your production :) 
+As usual, please don't do this on your production :)
 
 ### Setup
 
@@ -80,7 +76,7 @@ Create and enter your Scaleway credentials with:
 kubectl create -f https://raw.githubusercontent.com/Sh4d1/scaleway-external-ip/main/secret.yaml --edit --namespace scaleway-external-ip-system
 ```
 
-You are now ready to create Routed IPs, add them to `externalIPs` in a service, and create a `ScwExternalIP` targeting this service! Yay!  
+You are now ready to create Routed IPs, add them to `externalIPs` in a service, and create a `ScwExternalIP` targeting this service! Yay!
 
 ## License
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,9 +19,11 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"github.com/patrickmn/go-cache"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -117,6 +119,7 @@ func main() {
 			Client:    mgr.GetClient(),
 			Scheme:    mgr.GetScheme(),
 			ScwClient: scwClient,
+			Cache:     *cache.New(5*time.Second, time.Minute),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ScwExternalIP")
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -47,7 +48,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vishvananda/netlink v1.1.0 // indirect
-	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -130,8 +132,12 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
+github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -189,6 +195,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/controller/scwexternalip_controller.go
+++ b/internal/controller/scwexternalip_controller.go
@@ -64,7 +64,7 @@ const (
 type NodeNameID struct {
 	Name   string
 	ID     string
-	EIpIds []string
+	eipIDs []string
 }
 
 type Cache interface {
@@ -196,7 +196,7 @@ func (r *ScwExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 			// Sort the possibleNodes to make sure to spread IPs to all the nodes
 			sort.Slice(possibleNodes, func(i, j int) bool {
-				return len(possibleNodes[i].EIpIds) < len(possibleNodes[j].EIpIds)
+				return len(possibleNodes[i].eipIDs) < len(possibleNodes[j].eipIDs)
 			})
 
 			var nodeName, nodeID string
@@ -204,7 +204,7 @@ func (r *ScwExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if ip.Server != nil {
 				// IP already attached to a server
 				for _, nni := range possibleNodes {
-					if slices.Contains(nni.EIpIds, ip.ID) {
+					if slices.Contains(nni.eipIDs, ip.ID) {
 						nodeName = nni.Name
 						nodeID = nni.ID
 						break
@@ -570,12 +570,12 @@ func (r *ScwExternalIPReconciler) findNodes(ctx context.Context, zone string, no
 		}
 
 		for _, s := range resp.Servers {
-			eIpIds := make([]string, len(s.PublicIPs))
+			eipIDs := make([]string, len(s.PublicIPs))
 			for _, ip := range s.PublicIPs {
-				eIpIds = append(eIpIds, ip.ID)
+				eipIDs = append(eipIDs, ip.ID)
 			}
 			if slices.Contains(nodeNames, s.Name) {
-				nodeNamesIDs = append(nodeNamesIDs, NodeNameID{Name: s.Name, ID: s.ID, EIpIds: eIpIds})
+				nodeNamesIDs = append(nodeNamesIDs, NodeNameID{Name: s.Name, ID: s.ID, eipIDs: eipIDs})
 			}
 		}
 	}

--- a/internal/controller/scwexternalip_controller.go
+++ b/internal/controller/scwexternalip_controller.go
@@ -23,8 +23,11 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	corev1 "k8s.io/api/core/v1"
@@ -54,9 +57,19 @@ var (
 	finalizer    = "ptrk.io/finalizer"
 )
 
+const (
+	cacheKey string = "scwIpCache"
+)
+
 type NodeNameID struct {
-	Name string
-	ID   string
+	Name   string
+	ID     string
+	EIpIds []string
+}
+
+type Cache interface {
+	Set(cacheKey string, value interface{}, maxAge time.Duration)
+	Get(cacheKey string) (value interface{}, found bool)
 }
 
 // ScwExternalIPReconciler reconciles a ScwExternalIP object
@@ -64,6 +77,7 @@ type ScwExternalIPReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	ScwClient *scw.Client
+	Cache     Cache
 }
 
 //+kubebuilder:rbac:groups=ptrk.io,resources=scwexternalips,verbs=get;list;watch;create;update;patch;delete
@@ -180,17 +194,24 @@ func (r *ScwExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				continue
 			}
 
+			// Sort the possibleNodes to make sure to spread IPs to all the nodes
+			sort.Slice(possibleNodes, func(i, j int) bool {
+				return len(possibleNodes[i].EIpIds) < len(possibleNodes[j].EIpIds)
+			})
+
 			var nodeName, nodeID string
 
 			if ip.Server != nil {
+				// IP already attached to a server
 				for _, nni := range possibleNodes {
-					if ip.Server.Name == nni.Name {
+					if slices.Contains(nni.EIpIds, ip.ID) {
 						nodeName = nni.Name
 						nodeID = nni.ID
 						break
 					}
 				}
 				if nodeName == "" {
+					// IP not attached to a possible node
 					node := &corev1.Node{}
 					err := r.Get(ctx, types.NamespacedName{Name: ip.Server.Name}, node)
 					if client.IgnoreNotFound(err) != nil {
@@ -275,6 +296,7 @@ func (r *ScwExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					})
 				}
 			} else {
+				// IP not attached to a server
 				for i, s := range possibleNodes {
 					_, err = api.UpdateIP(&instance.UpdateIPRequest{
 						// TODO: add reverse ?
@@ -334,12 +356,10 @@ func (r *ScwExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *ScwExternalIPReconciler) getInstanceIPMap() (map[string]*instance.IP, error) {
-	api := instance.NewAPI(r.ScwClient)
+
 	ipMap := make(map[string]*instance.IP)
 
-	// TODO: fix this quickwin for the region, or at least document
-	// TODO cache IPs
-	resp, err := api.ListIPs(&instance.ListIPsRequest{}, scw.WithZones(scw.Region(os.Getenv("SCW_REGION")).GetZones()...), scw.WithAllPages())
+	resp, err := r.getCachedAPIResponse()
 	if err != nil {
 		return nil, fmt.Errorf("unable to list scw ips: %w", err)
 	}
@@ -353,6 +373,23 @@ func (r *ScwExternalIPReconciler) getInstanceIPMap() (map[string]*instance.IP, e
 	}
 
 	return ipMap, nil
+}
+
+// getCachedAPIResponse returns the cached API response if available, otherwise it fetches from the API.
+func (r *ScwExternalIPReconciler) getCachedAPIResponse() (*instance.ListIPsResponse, error) {
+	if cachedResponse, found := r.Cache.Get(cacheKey); found {
+		return cachedResponse.(*instance.ListIPsResponse), nil
+	}
+
+	api := instance.NewAPI(r.ScwClient)
+	// TODO: fix this quickwin for the region, or at least document
+	res, err := api.ListIPs(&instance.ListIPsRequest{}, scw.WithZones(scw.Region(os.Getenv("SCW_REGION")).GetZones()...), scw.WithAllPages())
+	if err != nil {
+		return nil, err
+	}
+
+	r.Cache.Set(cacheKey, res, cache.DefaultExpiration)
+	return res, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -533,8 +570,12 @@ func (r *ScwExternalIPReconciler) findNodes(ctx context.Context, zone string, no
 		}
 
 		for _, s := range resp.Servers {
+			eIpIds := make([]string, len(s.PublicIPs))
+			for _, ip := range s.PublicIPs {
+				eIpIds = append(eIpIds, ip.ID)
+			}
 			if slices.Contains(nodeNames, s.Name) {
-				nodeNamesIDs = append(nodeNamesIDs, NodeNameID{Name: s.Name, ID: s.ID})
+				nodeNamesIDs = append(nodeNamesIDs, NodeNameID{Name: s.Name, ID: s.ID, EIpIds: eIpIds})
 			}
 		}
 	}


### PR DESCRIPTION
Hello @Sh4d1 👋 

The idea of this PR is to improve how the External IPs are shared accross Kubernetes nodes. We want to avoid having all the IPs attached to the same Node in order to reduce the blast radius of a node failure. 

I also added a cache for IP listing from Instance API as it was suggested :) 
